### PR TITLE
Convert to boolean

### DIFF
--- a/quickstack/manifests/neutron/controller.pp
+++ b/quickstack/manifests/neutron/controller.pp
@@ -395,9 +395,9 @@ class quickstack::neutron::controller (
     auth_uri                         => $auth_uri,
     identity_uri                     => $identity_uri,
     auth_password                    => $neutron_user_password,
-    l3_ha                            => $l3_ha,
-    allow_automatic_l3agent_failover => $allow_automatic_l3agent_failover,
-  } 
+    l3_ha                            => str2bool_i($l3_ha),
+    allow_automatic_l3agent_failover => str2bool_i($allow_automatic_l3agent_failover),
+  }
 
   if $neutron_core_plugin == 'neutron.plugins.ml2.plugin.Ml2Plugin' {
 


### PR DESCRIPTION
This check makes sure that the passed variables are converted
to boolean since subsequent classes require them as boolean in
their checks, else it will always come out as true.
