### PR TITLE
Sahara: Change Vanilla 2.6 paths to 2.7

### DIFF
--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -216,6 +216,18 @@ class quickstack::sahara (
     after   => "                'data-jobtype-java': _\u0028\"Choose libraries\"\u0029,"
   }
 
+  file_line { 'mr_26':
+    path    => '/usr/lib/python2.7/site-packages/sahara/service/edp/oozie/workflow_creator/workflow_factory.py',
+    line    => "            'plugins/vanilla/v2_7_1/resources/mapred-default.xml')",
+    match   => '.*(mapred-default).*'
+  }
+
+  file_line { 'hive_26':
+    path    => '/usr/lib/python2.7/site-packages/sahara/service/edp/oozie/workflow_creator/workflow_factory.py',
+    line    => "            'plugins/vanilla/v2_7_1/resources/hive-default.xml')",
+    match   => '.*(hive-default).*'
+  }
+
   #file_line { 'disable_floating':
   #  notify  => Service['httpd'], # only restarts if a file changes
   #  path    => '/etc/openstack-dashboard/local_settings',

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -217,12 +217,14 @@ class quickstack::sahara (
   }
 
   file_line { 'mr_26':
+    notify => Service['openstack-sahara-all'],
     path    => '/usr/lib/python2.7/site-packages/sahara/service/edp/oozie/workflow_creator/workflow_factory.py',
     line    => "            'plugins/vanilla/v2_7_1/resources/mapred-default.xml')",
     match   => '.*(mapred-default).*'
   }
 
   file_line { 'hive_26':
+    notify => Service['openstack-sahara-all'],
     path    => '/usr/lib/python2.7/site-packages/sahara/service/edp/oozie/workflow_creator/workflow_factory.py',
     line    => "            'plugins/vanilla/v2_7_1/resources/hive-default.xml')",
     match   => '.*(hive-default).*'


### PR DESCRIPTION
When launching Hive and MapReduce jobs on Vanilla clusters, Sahara needs to generate a configuration file. The problem is, it gets the template from the Vanilla 2.6 folder. I had deleted this folder in order to hide old, unsupported plugin versions. This PR changes the path of the configuration template to the Vanilla 2.7 folder. 
