### PR TITLE
Sahara: Disable /etc/hosts entry for Swift

### DIFF
--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -236,10 +236,10 @@ class quickstack::sahara (
   #  line    => 'SAHARA_AUTO_IP_ALLOCATION_ENABLED=True'
   #}
 
-  file_line { 'keystone_dns':
+  file_line { 'disable_etc_hosts':
     notify => Service['openstack-sahara-all'], # only restarts if change
     path   => '/usr/lib/python2.7/site-packages/sahara/utils/cluster.py',
-    line   => "    for service in [\"object-store\"]:",
+    line   => "    for service in []:",
     match  => "(    for service in).*"
   }
 


### PR DESCRIPTION
The fake rdgwengage1.massopencloud.org endpoint causes Sahara cluster deployment to fail. 

It tries to make entry in /etc/hosts file in Sahara instances for this endpoint, but it cannot translate the hostname into an IP address, since it points to nowhere.

This PR disables the attempt to add that entry to /etc/hosts.
