### PR TITLE
Sahara: Re-enable /etc/hosts entry for Swift endpoint

### DIFF
--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -239,7 +239,7 @@ class quickstack::sahara (
   file_line { 'disable_etc_hosts':
     notify => Service['openstack-sahara-all'], # only restarts if change
     path   => '/usr/lib/python2.7/site-packages/sahara/utils/cluster.py',
-    line   => "    for service in []:",
+    line   => "    for service in [\"object-store\"]:",
     match  => "(    for service in).*"
   }
 


### PR DESCRIPTION
Originally I had to disable creation /etc/hosts entry for Swift endpoint in Sahara cluster due to this bug: https://bugs.launchpad.net/sahara/+bug/1616112 (patched by me in Newton release!).  

Now we have Swift endpoint in Engage1, so I can revert the temporary bug fix.